### PR TITLE
Don't overwrite existing key mappings

### DIFF
--- a/doc/vim-spec-runner.txt
+++ b/doc/vim-spec-runner.txt
@@ -29,10 +29,17 @@ and then:
 ========================================================================
 3. USAGE                                            *VimSpecRunnerUsage*
 
-Key-Bindings for Vim Spec-Runner:
-  
+By default, Vim Spec-Runner comes with these mappings:
+
   <leader>t             Execute the whole test file
   <leader>T             Execute the test around the current cursor
                         position
   <leader>a             Run all the tests
 
+However, the plugin won't overwrite a pre-existing mapping so if you
+prefer to define different mappings use lines like these in your
+~/.vimrc:
+
+  nnoremap <leader>t :RunTestFile<cr>
+  nnoremap <leader>T :RunNearestTest<cr>
+  nnoremap <leader>a :RunAllTests<cr>

--- a/plugin/vim-spec-runner.vim
+++ b/plugin/vim-spec-runner.vim
@@ -7,9 +7,17 @@ command RunTestFile    call <SID>RunTestFile()
 command RunNearestTest call <SID>RunNearestTest()
 command RunAllTests    call <SID>RunTests('')
 
-nnoremap <leader>t :RunTestFile<cr>
-nnoremap <leader>T :RunNearestTest<cr>
-nnoremap <leader>a :RunAllTests<cr>
+if !hasmapto(':RunTestFile<cr>')
+  nnoremap <leader>t :RunTestFile<cr>
+endif
+
+if !hasmapto(':RunNearestTest<cr>')
+  nnoremap <leader>T :RunNearestTest<cr>
+endif
+
+if !hasmapto(':RunAllTests<cr>')
+  nnoremap <leader>a :RunAllTests<cr>
+endif
 
 function s:RunTestFile(...)
   if a:0


### PR DESCRIPTION
This makes sure that pre-existing key mappings like `<leader>t` aren't overwritten.

Also adds dedicated commands for simpler mappings, e.g.

``` vim
nnoremap <leader>t :RunTestFile<cr>
nnoremap <leader>T :RunNearestTest<cr>
nnoremap <leader>a :RunAllTests<cr>
```
