### PR TITLE
Support project-specific test script

### DIFF
--- a/plugin/vim-spec-runner.vim
+++ b/plugin/vim-spec-runner.vim
@@ -56,11 +56,8 @@ function s:RunTests(filename)
   if filereadable("script/test")
     exec ":!./script/test " . a:filename
     return
-  end
-
-  " Jimdo Puppet Sondergeloet
-  if filereadable("scripts/spec-runner")
-    exec ":!./scripts/spec-runner " . a:filename
+  elseif filereadable("scripts/test")
+    exec ":!./scripts/test " . a:filename
     return
   end
 

--- a/plugin/vim-spec-runner.vim
+++ b/plugin/vim-spec-runner.vim
@@ -52,6 +52,12 @@ function s:RunTests(filename)
     :w
   end
 
+  " First choice: project-specific test script
+  if filereadable("script/test")
+    exec ":!./script/test " . a:filename
+    return
+  end
+
   " Jimdo Puppet Sondergeloet
   if filereadable("scripts/spec-runner")
     exec ":!./scripts/spec-runner " . a:filename


### PR DESCRIPTION
Thereby getting rid of the Jimdo Puppet Sondergeloet and - even better - allowing us to use the plugin to test any code as long as `script/test` or `scripts/test` exist.

Example for Go: https://github.com/mlafeldt/go-ghstatus/pull/5/files
